### PR TITLE
Fix newlines in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,20 @@ polyfy /path/to/image <options>
 ```
 
 #####options:
-`r|g|b` Choose r, g, b, or any combination of the three ( bg rg ) to control which colors turn negative (default: rgb)  
-`traingle|square|diamond|circle` Draw a triangle, square, diamond or circle (default: diamond)  
-`-s or --size <size>` Change the polygon size as a fraction of the image's height (default: 3 #this means the polygon side length is 1/3 of the image's height)  
-`-b or --borderwidth <borderwidth>` Change the border width of the polygons (default: 10)  
+`r|g|b` Choose r, g, b, or any combination of the three ( bg rg ) to control which colors turn negative (default: rgb)
+
+`traingle|square|diamond|circle` Draw a triangle, square, diamond or circle (default: diamond)
+
+`-s or --size <size>` Change the polygon size as a fraction of the image's height (default: 3 #this means the polygon side length is 1/3 of the image's height)
+
+`-b or --borderwidth <borderwidth>` Change the border width of the polygons (default: 10)
+
 `--blur <number>` Blur the background outside the polygon
-`-r1 or --rotation1 <degrees>` Rotate the first polygon  
-`-r2 or --rotation2 <degrees>` Rotate the second polygon  
+
+`-r1 or --rotation1 <degrees>` Rotate the first polygon
+
+`-r2 or --rotation2 <degrees>` Rotate the second polygon
+
 `over|under|none` Choose if the second polygon is drawn over the first, under, or not at all (default: over)
 
 


### PR DESCRIPTION
The `-r1` option in the README was run on with the `--blur` option.

Spacing them out more ensures that they're all on their own line and has the added benefit of making it a hint easier to read.
