### PR TITLE
Rewrote script for readability and consistency.

### DIFF
--- a/polyfy
+++ b/polyfy
@@ -1,17 +1,24 @@
 #! /usr/bin/env sh
 #
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  (at your option) any later version.
+# Copyright (c) 2015
 #
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-#  GNU General Public License for more details.
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
 #
-#  You should have received a copy of the GNU General Public License
-#  along with this program; if not, see <http://www.gnu.org/licenses/>.
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 
 SHORT="hr:s:o:"
 LONG="help,rotate:,blur:,border-color:,border-width:,overlay:,size:,red,blue,green,rgb,shape:"

--- a/polyfy
+++ b/polyfy
@@ -1,157 +1,248 @@
 #! /bin/bash
 
-#adds totally awesome polygons to any wallpaper
-#check if file is specified
+SHORT="hr:s:o:"
+LONG="help,rotate:,blur:,border-color:,border-width:,overlay:,size:,red,blue,green,rgb,shape:"
+OPTIONS=$(getopt -o $(echo $SHORT) \
+                 -l $(echo $LONG | sed 's/ //g') \
+                 -n "$0" \
+                 -- "$@")
 
-usage () {
-        printf "Usage: polyfy /path/to/file /path/to/clipping <options> \n\
-Available options: \n\
-r|g|b or any combination of the three - which color channels to negate (default: none) \n\
-triangle|diamond|square|circle - what shape to draw (default: diamond) \n\
-over|under|none - draw the second polygon over or under the first, or not at all (default: over) \n\
--b <number> - width of border (default: 10) \n\
--s <number> - size of polygon as a fraction of image height (default: 3) \n\
---blur <number> - amount to blur image, excluding area inside polygon (default: 0) \n\
--r or --rotate <degree1> <degrees2> - amount to rotate polygon 1 (degrees1) and polygon 2 (degrees2) \n";
-                exit 0;
-}
-
-triangle () {
-        length=$(echo "$imageheight/${size//[^0-9-.]/}" | bc -l | awk '{print int($1+0.5)}');
-        height=$(echo "$length * sqrt(3) / 2" | bc -l | awk '{print int($1+0.5)}');
-        path1="polygon $((length/2)),0 $length,$height 0,$height";
-        rotate1="0";
-        rotate2="180";
-}
-
-square () {
-        length=$(echo "$imageheight/${size//[^0-9-.]/}" | bc -l | awk '{print int($1+0.5)}');
-        height=$length;
-        path1="rectangle 0,0 $length,$height";
-        rotate1="0";
-        rotate2="45";
-}
-
-diamond () {
-        square;
-        rotate1="45";
-}
-
-
-circle () {
-        length=$(echo "$imageheight/${size//[^0-9-.]/}" | bc -l | awk '{print int($1+0.5)}');
-        height=$length;
-        path1="circle $((length/2)),$((height/2)) $((length/2)),$borderwidth";
-        rotate1="0"
-        rotate2="0"
-}
-
-#default variables
+# Default variables
 bordercolor="white"
 borderwidth="10"
 channel="rgb"
+negate=""
 size="3"
 shape="diamond"
 border2="over"
-file="${1//~/$HOME}"; shift #get file
 
-if [ ! -f $file ]; then #check if file exists
-        usage
-else
+while true; do
+    case "$1" in
+        --red)
+            [[ ! $negate =~ "r" ]] && negate="${negate}r"
+            shift ;;
+        --green)
+            [[ ! $negate =~ "g" ]] && negate="${negate}g"
+            shift ;;
+        --blue)
+            [[ ! $negate =~ "b" ]] && negate="${negate}b"
+            shift ;;
+        --rgb)
+            negate="rgb"
+            shift ;;
+        -r|--rotate)
+            rotation1="${2%,*}"
+            rotation2="${2#*,}"
+            shift 2 ;;
+        -o|--overlay)
+            border2="$2"
+            shift 2 ;;
+        --blur)
+            blur="-blur $2"
+            shift 2 ;;
+        --size)
+            size="$2"
+            shift 2 ;;
+        -s|--shape)
+            shape="$2"
+            shift 2 ;;
+        --border-width)
+            borderwidth="$2"
+            shift 2 ;;
+        --border-color)
+            borderwidth="$2"
+            shift 2 ;;
+        -h|--help)
+            echo "
+$(tput bold)NAME$(tput sgr0)
+    Polyfy - Add cool polygons to any wallpaper
 
-        if (( $# != 0 ))  && [ -f $1 ]; then #check if second file is given
-                file2="${1//~/$HOME}"; shift
-        else
-                file2="$file"
-        fi
+$(tput bold)SYNOPSIS$(tput sgr0)
+    polyfy $(tput bold)[options]$(tput sgr0) $(tput bold)[file...]$(tput sgr0)
 
-        filename=$(basename ${file%.*})
-        format=$(basename ${file##*.})
-        directory=$(dirname $file)
-        imagewidth=$(identify -format "%w" $file)
-        imageheight=$(identify -format "%h" $file)
-        
-        #add number to filename if output file already exists
-        if [[ -e $directory/$filename-polyfy.$format ]] ; then
-                i=2
-                while [[ -e $directory/$filename-polyfy"$i".$format ]] ; do
-                        let i++
-                done
-        fi
-        filename=$directory/$filename-polyfy"$i".$format
-fi
+$(tput bold)DESCRIPTION$(tput sgr0)
+    A short description about it.
 
-#get options
-for i in "$@"
-do
-        case $1 in
-                r|g|b|rg|rb|gr|br|gb|bg|rgb|rbg|brg|bgr|grb|gbr)
-                        negate="-channel ${1//[^rgb]/} -negate"
-                        shift
-                        ;;
-                -b|--borderwidth)
-                        borderwidth="${2//[^0-9]/}"
-                        shift 2
-                        ;;
-                -s|--size)
-                        size="$2"
-                        shift 2
-                        ;;
-                --blur)
-                        blur="-blur 0x$2"
-                        shift 2
-                        ;;
-                -r|--rotate)
-                        rotation1="$2"
-                        rotation2="$3"
-                        shift 3
-                        ;;
-                triangle|square|diamond|circle)
-                        shape="$1"
-                        shift
-                        ;;
-                over)
-                        shift
-                        ;;
-                under|behind)
-                        border2="under"
-                        shift
-                        ;;
-                none)
-                        border2="none"
-                        shift
-                        ;;
-                *)
-                        ;;
-        esac
+$(tput bold)OPTIONS$(tput sgr0)
+    $(tput bold)-h, --help $(tput sgr0)
+        You're looking at it.
+
+    $(tput bold)-r, --rotate$(tput sgr0) <first>,<second>
+        Specify the rotations done on the first and second polygon. You are to
+        split the degrees with a ',' delimiter.
+
+    $(tput bold)--border-width$(tput sgr0) <number>
+        The border width.
+
+        The default value is 10.
+
+    $(tput bold)--border-color$(tput sgr0) <number>
+        The color of the border.
+
+        The default calue is white.
+
+    $(tput bold)--blur$(tput sgr0) <radius>x<sigma>
+        Amount to blur the image excluding the area inside polygon. You are to
+        split the values with a 'x'. The important setting in the above is the
+        second sigma value. It can be thought of as an approximation of just
+        how much your want the image to 'spread' or blur, in pixels. Think of
+        it as the size of the brush used to blur the image. The numbers are
+        floating point values, so you can use a very small value like '0.5'.
+
+        The first value radius, is also important as it controls how big an
+        area the operator should look at when spreading pixels. This value
+        should typically be either '0' or at a minimum double that of the sigma.
+
+        The default is 0x0 for every shape.
+
+    $(tput bold)--size$(tput sgr0) <number>
+        The size of polygon as a fraction of image height.
+
+        The default value is 3.
+
+    $(tput bold)-s, --shape$(tput sgr0) <type>
+        What shape should be drawn. You can find the default values of every
+        shape in the $(tput bold)--rotate$(tput sgr0) section.
+        The available shapes are: Diamond, square, circle, triangle.
+
+        By default the shape will be a diamond.
+
+    $(tput bold)--red, --blue, --green$(tput sgr0)
+        Specify which color channels to negate. None of these flags take any
+        argument and can be specified in any sequence.
+
+            --red --blue --green
+            --blue --green
+            --red
+
+        Alternatively you can also use $(tput bold)--rgb$(tput sgr0) to negate
+        all the channels. This is only shorthand for specify all the flags seperately.
+
+        By default there will be no negated channels.
+
+    $(tput bold)-o, --overlay$(tput sgr0) <type>
+        Draw the second polygon over or under the first, or not at all.
+
+        | Type    | Description                                 |
+        |-------------------------------------------------------|
+        | Under   | Draw a second polying beneath the first one |
+        | Over    | Draw a second polygon over the first one    |
+        | None    | Don't draw a second polygon                 |
+
+        The default will be 'over'.
+            "
+            exit  ;;
+        --) shift
+            break ;;
+        * ) break ;;
+    esac
 done
 
-$shape #calls chosen shape function
+# Update the negate variables to fit the convert syntax.
+negate="-channel $negate -negate"
 
-#conversion with imagemagick
-convert -size "$length"x"$height" xc:none -fill black -draw "$path1" -background none -rotate $((rotation1+rotate1)) /tmp/polyfy1.png #make the matte
-convert $file2 /tmp/polyfy1.png -gravity center -alpha set -compose Dstin -composite $negate -trim +repage /tmp/polyfy2.png #cut out the first polygon from the original image and negate it
+[[ -f ${1} ]] && {
+    file="${1//~/$HOME}"
+    shift
+    [[ -f ${1} ]] && {
+        file2="${1//~/$HOME}"
+        shift
+    } || {
+        file2=$file
+    }
+} || {
+    echo "You did not specify a file."
+    exit 0
+}
 
-if [ $borderwidth -ne 0 ]; then #check if border is not 0
-        convert -size "$length"x"$height" xc:none -stroke $bordercolor -strokewidth $borderwidth -fill none -draw "$path1" -background none -rotate $((rotation1+rotate1)) /tmp/polyfy1.png #draw the border
-        case $border2 in
-                over)
-                        convert -gravity center -background none /tmp/polyfy1.png -rotate $((rotation2+rotate2)) /tmp/polyfy1.png -compose Over -composite /tmp/polyfy1.png #combine the border and rotated border
-                        convert -gravity center /tmp/polyfy1.png /tmp/polyfy2.png -compose DstOver -composite /tmp/polyfy2.png #place borders over clipping
-                        ;;
-                under)
-                        convert -gravity center -background none /tmp/polyfy1.png -rotate $((rotation2+rotate2)) /tmp/polyfy2.png -compose Over -composite /tmp/polyfy2.png #place rotated border under clipping 
-                        convert -gravity center -background none /tmp/polyfy2.png /tmp/polyfy1.png -compose Over -composite /tmp/polyfy2.png #place border over clipping
-                        ;;
-                none)
-                        convert -gravity center /tmp/polyfy1.png /tmp/polyfy2.png -compose DstOver -composite /tmp/polyfy2.png #place border over clipping 
-                        ;;
-        esac
-fi
+imageheight=$(identify -format "%h" $file)
+imagewidth=$(identify -format "%w" $file)
+directory=$(dirname $file)
+filename=$(basename ${file%.*})
+format=$(basename ${file##*.})
 
-convert -gravity center $file $blur /tmp/polyfy2.png -compose Over -composite $filename #combine clipping and original image, apply blur
+[[ -e $directory/$filename-polyfy.$format ]] && {
+    i=2
+    while [[ -e $directory/$filename-polyfy"$i".$format ]]; do
+        let i++
+    done
+}
+filename=$directory/$filename-polyfy"$i".$format
 
-rm -f /tmp/polyfy{1,2}.png #remove temporary files
+triangle() {
+    length=$(echo "$imageheight/${size//[^0-9-.]/}" | bc -l | awk '{print int($1+0.5)}')
+    height=$(echo "$length * sqrt(3) / 2" | bc -l | awk '{print int($1+0.5)}');
+    path1="polygon $((length/2)),0 $length,$height 0,$height";
+    rotate1="0";
+    rotate2="180";
+}
 
-echo "file saved to $filename" #output where the finished image was saved
+square() {
+    length=$(echo "$imageheight/${size//[^0-9-.]/}" | bc -l | awk '{print int($1+0.5)}');
+    height=$length;
+    path1="rectangle 0,0 $length,$height";
+    rotate1="0";
+    rotate2="45";
+}
 
+diamond () {
+    square;
+    rotate1="45";
+}
+
+circle () {
+    length=$(echo "$imageheight/${size//[^0-9-.]/}" | bc -l | awk '{print int($1+0.5)}');
+    height=$length;
+    path1="circle $((length/2)),$((height/2)) $((length/2)),$borderwidth";
+    rotate1="0"
+    rotate2="0"
+}
+
+$shape
+
+convert -size "$length"x"$height" xc:none -fill black -draw "$path1" \
+        -background none -rotate $((rotation1+rotate1)) /tmp/polyfy1.png
+
+# Cut out the first polygon from the original image and negate it.
+convert $file2 /tmp/polyfy1.png -gravity center -alpha set -compose Dstin \
+        -composite $negate -trim +repage /tmp/polyfy2.png
+
+[[ $borderwidth -ne 0 ]] && {
+    # Draw the border.
+    convert -size "$length"x"$height" xc:none -stroke $bordercolor \
+            -strokewidth $borderwidth -fill none -draw "$path1" -background none \
+            -rotate $((rotation1+rotate1)) /tmp/polyfy1.png
+
+    case $border2 in
+            over)
+                # Combine the border and rotated border.
+                convert -gravity center -background none /tmp/polyfy1.png \
+                        -rotate $((rotation2+rotate2)) /tmp/polyfy1.png \
+                        -compose Over -composite /tmp/polyfy1.png
+                convert -gravity center /tmp/polyfy1.png /tmp/polyfy2.png -compose DstOver -composite /tmp/polyfy2.png #place borders over clipping
+                ;;
+            under)
+                # Place rotated border under clipping
+                convert -gravity center -background none /tmp/polyfy1.png \
+                        -rotate $((rotation2+rotate2)) /tmp/polyfy2.png \
+                        -compose Over -composite /tmp/polyfy2.png
+                # Place border over clipping
+                convert -gravity center -background none /tmp/polyfy2.png \
+                        /tmp/polyfy1.png -compose Over -composite /tmp/polyfy2.png
+                ;;
+            none)
+                # Place border over clipping.
+                convert -gravity center /tmp/polyfy1.png /tmp/polyfy2.png \
+                        -compose DstOver -composite /tmp/polyfy2.png
+                ;;
+    esac
+}
+
+# Combine clipping and original image, apply blur
+convert -gravity center $file $blur /tmp/polyfy2.png -compose Over -composite $filename
+
+# Remove temporary files.
+rm -f /tmp/polyfy{1,2}.png
+
+# Tell the user where and what.
+echo "file saved to $filename"

--- a/polyfy
+++ b/polyfy
@@ -20,10 +20,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-SHORT="hr:s:o:"
-LONG="help,rotate:,blur:,border-color:,border-width:,overlay:,size:,red,blue,green,rgb,shape:"
-OPTIONS=$(getopt -o $(echo $SHORT) \
-                 -l $(echo $LONG) \
+SHORT="hr:s:o:n:"
+LONG="help,rotate:,blur:,border-color:,border-width:,overlay:,negate:,size:,shape:"
+OPTIONS=$(getopt -o $SHORT \
+                 -l $LONG \
                  -n "$0" \
                  -- "$@")
 
@@ -40,18 +40,11 @@ dup_c=2
 
 while true; do
     case "$1" in
-        --red)
-            [[ ! $negate =~ "r" ]] && negate="${negate}r"
-            shift ;;
-        --green)
-            [[ ! $negate =~ "g" ]] && negate="${negate}g"
-            shift ;;
-        --blue)
-            [[ ! $negate =~ "b" ]] && negate="${negate}b"
-            shift ;;
-        --rgb)
-            negate="rgb"
-            shift ;;
+        -n|--negate)
+            # TODO: Elegant of not parsing the -channel and -negate when there's
+            # other characters specified apart from 'rgb'.
+            negate="-channel ${2//[^rgb]/} -negate"
+            shift 2 ;;
         -r|--rotate)
             rotation_f="${2%,*}"
             rotation_s="${2#*,}"
@@ -91,15 +84,7 @@ $(tput bold)OPTIONS$(tput sgr0)
 
     $(tput bold)-r, --rotate$(tput sgr0) <first>,<second>
         Specify the rotations done on the first and second polygon. You are to
-        split the degrees with a ',' delimiter. These values extend the
-        exisiting (default) values.
-
-            | Shape    | first | second |
-            |---------------------------|
-            | Diamond  | 45    | *      |
-            | Triangle | 0     | 180    |
-            | Square   | 0     | 45     |
-            | Circle   | 0     | 0      |
+        split the degrees with a ',' delimiter.
 
     $(tput bold)--border-width$(tput sgr0) <number>
         The border width.
@@ -133,20 +118,14 @@ $(tput bold)OPTIONS$(tput sgr0)
     $(tput bold)-s, --shape$(tput sgr0) <type>
         What shape should be drawn. You can find the default values of every
         shape in the $(tput bold)--rotate$(tput sgr0) section.
-        The available shapes are: Diamond, square, circle, triangle.
+        The available shapes are: 'Diamond', 'square', 'circle' and triangle'.
 
         By default the shape will be a diamond.
 
-    $(tput bold)--red, --blue, --green$(tput sgr0)
-        Specify which color channels to negate. None of these flags take any
-        argument and can be specified in any sequence.
-
-            --red --blue --green
-            --blue --green
-            --red
-
-        Alternatively you can also use $(tput bold)--rgb$(tput sgr0) to negate
-        all the channels. This is only shorthand for specify all the flags seperately.
+    $(tput bold)-n, --negate$(tput sgr0) <channel>
+        Specify which color channels to negate. The available channels to negate
+        are: 'r', 'g' and 'b'. You are to specify the channels without any
+        delimiter.
 
         By default there will be no negated channels.
 
@@ -168,7 +147,6 @@ $(tput bold)OPTIONS$(tput sgr0)
     esac
 done
 
-[[ -n $negate ]] && negate="-channel $negate -negate"
 [[ -f ${1} ]] && {
     file_f="${1//~/$HOME}"; shift
     [[ -f ${1} ]] && {
@@ -180,16 +158,17 @@ done
     echo "You did not specify a file."
     exit 0
 }
-
-image_h=$(identify -format "%h" $file_f)
-image_w=$(identify -format "%w" $file_f)
 directory=$(dirname $file_f)
 filename=$(basename ${file_f%.*})
+image_h=$(identify -format "%h" $file_f)
+image_w=$(identify -format "%w" $file_f)
 format=$(basename ${file_f##*.})
 
-while [[ -e $directory/$filename-polyfy"$dup_c".$format ]]; do
-    let dup_c++
-done
+[[ -e $directory/$filename-polyfy.$format ]] && {
+    while [[ -e $directory/$filename-polyfy"$dup_c".$format ]]; do
+        let dup_c++
+    done
+}
 filename="$directory/$filename-polyfy"$dup_c".$format"
 
 triangle() {

--- a/polyfy
+++ b/polyfy
@@ -1,11 +1,26 @@
-#! /bin/bash
+#! /usr/bin/env sh
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 SHORT="hr:s:o:"
 LONG="help,rotate:,blur:,border-color:,border-width:,overlay:,size:,red,blue,green,rgb,shape:"
 OPTIONS=$(getopt -o $(echo $SHORT) \
-                 -l $(echo $LONG | sed 's/ //g') \
+                 -l $(echo $LONG) \
                  -n "$0" \
                  -- "$@")
+
+eval set -- "$OPTIONS"
 
 # Default variables
 border_c="white"

--- a/polyfy
+++ b/polyfy
@@ -8,12 +8,13 @@ OPTIONS=$(getopt -o $(echo $SHORT) \
                  -- "$@")
 
 # Default variables
-bordercolor="white"
-borderwidth="10"
+border_c="white"
+shape="diamond"
+overlay="over"
+border_w="10"
 channel="rgb"
 size="3"
-shape="diamond"
-border2="over"
+dup_c=2
 
 while true; do
     case "$1" in
@@ -30,11 +31,11 @@ while true; do
             negate="rgb"
             shift ;;
         -r|--rotate)
-            rotation1="${2%,*}"
-            rotation2="${2#*,}"
+            rotation_f="${2%,*}"
+            rotation_s="${2#*,}"
             shift 2 ;;
         -o|--overlay)
-            border2="$2"
+            overlay="$2"
             shift 2 ;;
         --blur)
             blur="-blur $2"
@@ -46,10 +47,10 @@ while true; do
             shape="$2"
             shift 2 ;;
         --border-width)
-            borderwidth="$2"
+            border_w="$2"
             shift 2 ;;
         --border-color)
-            bordercolor="$2"
+            border_c="$2"
             shift 2 ;;
         -h|--help)
             echo "
@@ -145,111 +146,104 @@ $(tput bold)OPTIONS$(tput sgr0)
     esac
 done
 
-# Update the negate variables to fit the convert syntax.
 [[ -n $negate ]] && negate="-channel $negate -negate"
-
 [[ -f ${1} ]] && {
-    file="${1//~/$HOME}"; shift
+    file_f="${1//~/$HOME}"; shift
     [[ -f ${1} ]] && {
-        file2="${1//~/$HOME}"; shift
+        file_s="${1//~/$HOME}"; shift
     } || {
-        file2=$file
+        file_s=$file_f
     }
 } || {
     echo "You did not specify a file."
     exit 0
 }
 
-imageheight=$(identify -format "%h" $file)
-imagewidth=$(identify -format "%w" $file)
-directory=$(dirname $file)
-filename=$(basename ${file%.*})
-format=$(basename ${file##*.})
+image_h=$(identify -format "%h" $file_f)
+image_w=$(identify -format "%w" $file_f)
+directory=$(dirname $file_f)
+filename=$(basename ${file_f%.*})
+format=$(basename ${file_f##*.})
 
-[[ -e $directory/$filename-polyfy.$format ]] && {
-    i=2
-    while [[ -e $directory/$filename-polyfy"$i".$format ]]; do
-        let i++
-    done
-}
-filename=$directory/$filename-polyfy"$i".$format
+while [[ -e $directory/$filename-polyfy"$dup_c".$format ]]; do
+    let dup_c++
+done
+filename="$directory/$filename-polyfy"$dup_c".$format"
 
 triangle() {
-    length=$(echo "$imageheight/${size//[^0-9-.]/}" | bc -l | awk '{print int($1+0.5)}')
-    height=$(echo "$length * sqrt(3) / 2" | bc -l | awk '{print int($1+0.5)}');
-    path1="polygon $((length/2)),0 $length,$height 0,$height";
-    rotate1="0";
-    rotate2="180";
+    length=$(echo "$image_h / $size" | bc -l | awk '{print int($1 + 0.5)}')
+    height=$(echo "$length * sqrt(3) / 2" | bc -l | awk '{print int($1 + 0.5)}')
+    rotate_s="180"
+    rotate_f="0"
+    path="polygon $((length / 2)),0 $length,$height 0,$height";
 }
 
 square() {
-    length=$(echo "$imageheight/${size//[^0-9-.]/}" | bc -l | awk '{print int($1+0.5)}');
-    height=$length;
-    path1="rectangle 0,0 $length,$height";
-    rotate1="0";
-    rotate2="45";
+    length=$(echo "$image_h / $size" | bc -l | awk '{print int($1 + 0.5)}')
+    height=$length
+    rotate_s="45"
+    rotate_f="0"
+    path="rectangle 0,0 $length,$height";
 }
 
-diamond () {
-    square;
-    rotate1="45";
+diamond() {
+    square
+    rotate_f="45"
 }
 
-circle () {
-    length=$(echo "$imageheight/${size//[^0-9-.]/}" | bc -l | awk '{print int($1+0.5)}');
-    height=$length;
-    path1="circle $((length/2)),$((height/2)) $((length/2)),$borderwidth";
-    rotate1="0"
-    rotate2="0"
+circle() {
+    length=$(echo "$image_h / $size" | bc -l | awk '{print int($1 + 0.5)}');
+    height=$length
+    rotate_s="0"
+    rotate_f="0"
+    path="circle $((length/2)),$((height/2)) $((length/2)),$border_w"
 }
 
+# Execute the assigned shape as function.
 $shape
 
-convert -size "$length"x"$height" xc:none -fill black -draw "$path1" \
-        -background none -rotate $((rotation1+rotate1)) /tmp/polyfy1.png
+convert -size "$length"x"$height" xc:none -fill black -draw "$path" \
+        -background none -rotate $((rotation_f+rotate_f)) /tmp/polyfy1.png
 
 # Cut out the first polygon from the original image and negate it.
-convert $file2 /tmp/polyfy1.png -gravity center -alpha set -compose Dstin \
+convert $file_s /tmp/polyfy1.png -gravity center -alpha set -compose Dstin \
         -composite $negate -trim +repage /tmp/polyfy2.png
 
-[[ $borderwidth -ne 0 ]] && {
+[[ $border_w -ne 0 ]] && {
     # Draw the border.
-    convert -size "$length"x"$height" xc:none -stroke $bordercolor \
-            -strokewidth $borderwidth -fill none -draw "$path1" -background none \
-            -rotate $((rotation1+rotate1)) /tmp/polyfy1.png
-
-    case $border2 in
-            over)
-                # Combine the border and rotated border.
-                convert -gravity center -background none /tmp/polyfy1.png \
-                        -rotate $((rotation2+rotate2)) /tmp/polyfy1.png \
-                        -compose Over -composite /tmp/polyfy1.png
-                # Place borders over clipping
-                convert -gravity center /tmp/polyfy1.png /tmp/polyfy2.png \
-                        -compose DstOver -composite /tmp/polyfy2.png
-                ;;
-            under)
-                # Place rotated border under clipping
-                convert -gravity center -background none /tmp/polyfy1.png \
-                        -rotate $((rotation2+rotate2)) /tmp/polyfy2.png \
-                        -compose Over -composite /tmp/polyfy2.png
-                # Place border over clipping
-                convert -gravity center -background none /tmp/polyfy2.png \
-                        /tmp/polyfy1.png -compose Over -composite /tmp/polyfy2.png
-                ;;
-            none)
-                # Place border over clipping.
-                convert -gravity center /tmp/polyfy1.png /tmp/polyfy2.png \
-                        -compose DstOver -composite /tmp/polyfy2.png
-                ;;
+    convert -size "$length"x"$height" xc:none -stroke $border_c \
+            -strokewidth $border_w -fill none -draw "$path" -background none \
+            -rotate $((rotation_f+rotate_f)) /tmp/polyfy1.png
+    case $overlay in
+        over)
+            # Combine the border and rotated border.
+            convert -gravity center -background none /tmp/polyfy1.png \
+                    -rotate $((rotation_s+rotate_s)) /tmp/polyfy1.png \
+                    -compose Over -composite /tmp/polyfy1.png
+            # Place borders over clipping
+            convert -gravity center /tmp/polyfy1.png /tmp/polyfy2.png \
+                    -compose DstOver -composite /tmp/polyfy2.png
+            ;;
+        under)
+            # Place rotated border under clipping
+            convert -gravity center -background none /tmp/polyfy1.png \
+                    -rotate $((rotation_s+rotate_s)) /tmp/polyfy2.png \
+                    -compose Over -composite /tmp/polyfy2.png
+            # Place border over clipping
+            convert -gravity center -background none /tmp/polyfy2.png \
+                    /tmp/polyfy1.png -compose Over -composite /tmp/polyfy2.png
+            ;;
+        none)
+            # Place border over clipping.
+            convert -gravity center /tmp/polyfy1.png /tmp/polyfy2.png \
+                    -compose DstOver -composite /tmp/polyfy2.png
+            ;;
     esac
 }
 
 # Combine clipping and original image, apply blur
-convert -gravity center $file $blur /tmp/polyfy2.png -compose Over -composite $filename
-
+convert -gravity center $file_f $blur /tmp/polyfy2.png -compose Over -composite $filename
 # Remove temporary files.
 rm -f /tmp/polyfy{1,2}.png
-
 # Tell the user where and what.
 echo "file saved to $filename"

--- a/polyfy
+++ b/polyfy
@@ -11,7 +11,6 @@ OPTIONS=$(getopt -o $(echo $SHORT) \
 bordercolor="white"
 borderwidth="10"
 channel="rgb"
-negate=""
 size="3"
 shape="diamond"
 border2="over"
@@ -50,7 +49,7 @@ while true; do
             borderwidth="$2"
             shift 2 ;;
         --border-color)
-            borderwidth="$2"
+            bordercolor="$2"
             shift 2 ;;
         -h|--help)
             echo "
@@ -69,14 +68,22 @@ $(tput bold)OPTIONS$(tput sgr0)
 
     $(tput bold)-r, --rotate$(tput sgr0) <first>,<second>
         Specify the rotations done on the first and second polygon. You are to
-        split the degrees with a ',' delimiter.
+        split the degrees with a ',' delimiter. These values extend the
+        exisiting (default) values.
+
+            | Shape    | first | second |
+            |---------------------------|
+            | Diamond  | 45    | *      |
+            | Triangle | 0     | 180    |
+            | Square   | 0     | 45     |
+            | Circle   | 0     | 0      |
 
     $(tput bold)--border-width$(tput sgr0) <number>
         The border width.
 
         The default value is 10.
 
-    $(tput bold)--border-color$(tput sgr0) <number>
+    $(tput bold)--border-color$(tput sgr0) <color>
         The color of the border.
 
         The default calue is white.
@@ -139,14 +146,12 @@ $(tput bold)OPTIONS$(tput sgr0)
 done
 
 # Update the negate variables to fit the convert syntax.
-negate="-channel $negate -negate"
+[[ -n $negate ]] && negate="-channel $negate -negate"
 
 [[ -f ${1} ]] && {
-    file="${1//~/$HOME}"
-    shift
+    file="${1//~/$HOME}"; shift
     [[ -f ${1} ]] && {
-        file2="${1//~/$HOME}"
-        shift
+        file2="${1//~/$HOME}"; shift
     } || {
         file2=$file
     }
@@ -219,7 +224,9 @@ convert $file2 /tmp/polyfy1.png -gravity center -alpha set -compose Dstin \
                 convert -gravity center -background none /tmp/polyfy1.png \
                         -rotate $((rotation2+rotate2)) /tmp/polyfy1.png \
                         -compose Over -composite /tmp/polyfy1.png
-                convert -gravity center /tmp/polyfy1.png /tmp/polyfy2.png -compose DstOver -composite /tmp/polyfy2.png #place borders over clipping
+                # Place borders over clipping
+                convert -gravity center /tmp/polyfy1.png /tmp/polyfy2.png \
+                        -compose DstOver -composite /tmp/polyfy2.png
                 ;;
             under)
                 # Place rotated border under clipping


### PR DESCRIPTION
I've been enjoying your scripts functionality, but the code itself was quite bothersome. 
- The variable names were a little... off?
- Inconsistency regarding the file arguments.
- There are really long lines regarding the `convert` section at the bottom.
- Not really any clear form of `--help` or usage.
- There's inconsistency regarding `[` and `[[`.
- Variables that were existent but not modifiable.

I've tried to rewrite most of the miscellaneous parts of the script and tried formatting the code a little better. There's now a detailed `--help` section available covering all the available flags and the _synopsis_. I've made the `border color` variable available for change, since it was defined but you couldn't change it. I changed all the `[` to `[[` and decided on  a single consistent way of calling if statements. The arguments are now handled through `getopt`. And last but not least, the lines at the bottom converting the image are now more readable.

Just throwing it out there, there's always the chance I oversaw one of the mentioned issues as well. 
