### PR TITLE
Fixed shebang and file naming

### DIFF
--- a/polyfy
+++ b/polyfy
@@ -1,4 +1,4 @@
-#! /usr/bin/env sh
+#! /usr/bin/env bash
 #
 # Copyright (c) 2015
 #
@@ -170,8 +170,10 @@ filename=$(basename ${file_f%.*})
 image_h=$(identify -format "%h" $file_f)
 image_w=$(identify -format "%w" $file_f)
 format=$(basename ${file_f##*.})
+dup_c=""
 
 [[ -e $directory/$filename-polyfy.$format ]] && {
+    dup_c=2
     while [[ -e $directory/$filename-polyfy"$dup_c".$format ]]; do
         let dup_c++
     done


### PR DESCRIPTION
Changed shebang from sh to bash (because we're using double brackets, which aren't supported by sh, and you're really not gonna find a _real_ copy of Bourne Shell outside actual Unix anyways...)

And naming works correctly now (first is -polyfy, second is -polyfy2, third is -polyfy3, etc). Luckily that was only two lines of code.
