### PR TITLE
Added --output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ polyfy /path/to/image <options>
 `-h or --help`
 Display the instructions
 
-`--output`
+`--output <filename>`
 Allows the output filename (and, optionally, directory) to be specified. The file extension should not be given as part of `filename`.                             
 If a directory is not specified, the file shall be saved in the current directory
                                                                                  

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ polyfy /path/to/image <options>
 `-h or --help`
 Display the instructions
 
-`--saveas`
+`--output`
 Allows the output filename (and, optionally, directory) to be specified. The file extension should not be given as part of `filename`.                             
 If a directory is not specified, the file shall be saved in the current directory
                                                                                  

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ polyfy path/to/image
 polyfy the image with the default options
 
 ```
-polyfy path/to/image -s diamond -n br --size 2 -b 20
+polyfy -s diamond -n br --size 2 -b 20 /path/to/image
 ```
 1. polyfy with a diamond
 2. negate the blue and red channels

--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ polyfy /path/to/image <options>
 `-h or --help`
 Display the instructions
 
+`--saveas`
+Allows the output filename (and, optionally, directory) to be specified. The file extension should not be given as part of `filename`.                             
+If a directory is not specified, the file shall be saved in the current directory
+                                                                                 
+The default filename is the input filename suffixed with "-polyfy".            
+The default directory is the current directory.                                  
+                                                                                 
+If the filename that polyfy attempts to use already exists, a number shall       
+be affixed to the end, starting with "2".                                      
+
 `-r or --rotate <first> <second>`
 Specify the rotations done on the first and second polygon. Split the degrees with a ',' 
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ be affixed to the end, starting with "2".
 `-r or --rotate <first> <second>`
 Specify the rotations done on the first and second polygon. Split the degrees with a ',' 
 
-`--border-width <number>`
+`-b or --border-width <number>`
 The border width.
 
 The default value is 10.

--- a/polyfy
+++ b/polyfy
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 SHORT="hr:s:o:n:"
-LONG="help,rotate:,blur:,border-color:,border-width:,overlay:,size:,negate:,shape:,saturate:,saveas:"
+LONG="help,rotate:,blur:,border-color:,border-width:,overlay:,size:,negate:,shape:,saturate:,output:"
 OPTIONS=$(getopt -o $(echo $SHORT) \
                  -l $(echo $LONG) \
                  -n "$0" \
@@ -61,8 +61,8 @@ while true; do
                 saturation="$2"
                 saturate="-modulate 100,$((saturation+100))"
             shift 2;;
-        --saveas)
-            saveas="$2"
+        --output)
+            output="$2"
             shift 2 ;;
         -s|--shape)
             shape="$2"
@@ -89,7 +89,7 @@ $(tput bold)OPTIONS$(tput sgr0)
     $(tput bold)-h, --help $(tput sgr0)
         You're looking at it.
 
-    $(tput bold)--saveas$(tput sgr0) <filename>
+    $(tput bold)--output$(tput sgr0) <filename>
         Allows the output filename (and, optionally, directory) to be specified. The file
         extension should not be given as part of `filename`.
         If a directory is not specified, the file shall be saved in the current directory.
@@ -186,7 +186,7 @@ image_w=$(identify -format "%w" $file_f)
 format=$(basename ${file_f##*.})
 dup_c=""
 
-if [[ -z $saveas ]]; then
+if [[ -z $output ]]; then
     [[ -e $directory/$filename-polyfy.$format ]] && {
         dup_c=2
         while [[ -e $directory/$filename-polyfy"$dup_c".$format ]]; do
@@ -195,8 +195,8 @@ if [[ -z $saveas ]]; then
     }
     filename="$directory/$filename-polyfy"$dup_c".$format"
 else
-    directory=$(dirname $saveas)
-    filename=$(basename ${saveas%.%})
+    directory=$(dirname $output)
+    filename=$(basename ${output%.%})
     [[ -e $directory/$filename.$format ]] && {
         dup_c=2
         while [[ -e $directory/$filename"$dup_c".$format ]]; do

--- a/polyfy
+++ b/polyfy
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-SHORT="hr:s:o:n:"
+SHORT="hr:s:o:n:b:"
 LONG="help,rotate:,blur:,border-color:,border-width:,overlay:,size:,negate:,shape:,saturate:,output:"
 OPTIONS=$(getopt -o $(echo $SHORT) \
                  -l $(echo $LONG) \
@@ -67,7 +67,7 @@ while true; do
         -s|--shape)
             shape="$2"
             shift 2 ;;
-        --border-width)
+        -b|--border-width)
             border_w="$2"
             shift 2 ;;
         --border-color)
@@ -104,7 +104,7 @@ $(tput bold)OPTIONS$(tput sgr0)
         Specify the rotations done on the first and second polygon. Split the 
         degrees with a ',' 
 
-    $(tput bold)--border-width$(tput sgr0) <number>
+    $(tput bold)-b, --border-width$(tput sgr0) <number>
         The border width.
 
         The default value is 10.

--- a/polyfy
+++ b/polyfy
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 SHORT="hr:s:o:n:"
-LONG="help,rotate:,blur:,border-color:,border-width:,overlay:,size:,negate:,shape:,saturate:"
+LONG="help,rotate:,blur:,border-color:,border-width:,overlay:,size:,negate:,shape:,saturate:,saveas:"
 OPTIONS=$(getopt -o $(echo $SHORT) \
                  -l $(echo $LONG) \
                  -n "$0" \
@@ -61,6 +61,9 @@ while true; do
                 saturation="$2"
                 saturate="-modulate 100,$((saturation+100))"
             shift 2;;
+        --saveas)
+            saveas="$2"
+            shift 2 ;;
         -s|--shape)
             shape="$2"
             shift 2 ;;
@@ -76,7 +79,7 @@ $(tput bold)NAME$(tput sgr0)
     Polyfy - Add cool polygons to any wallpaper
 
 $(tput bold)SYNOPSIS$(tput sgr0)
-    polyfy $(tput bold)[options]$(tput sgr0) $(tput bold)[file...]$(tput sgr0)
+    $(tput bold)polyfy$(tput sgr0) [$(tput bold)options$(tput sgr0)] $(tput smul)file$(tput sgr0)
 
 $(tput bold)DESCRIPTION$(tput sgr0)
     Please visit the site to find help, examples, and more information.
@@ -85,6 +88,17 @@ $(tput bold)DESCRIPTION$(tput sgr0)
 $(tput bold)OPTIONS$(tput sgr0)
     $(tput bold)-h, --help $(tput sgr0)
         You're looking at it.
+
+    $(tput bold)--saveas$(tput sgr0) <filename>
+        Allows the output filename (and, optionally, directory) to be specified. The file
+        extension should not be given as part of `filename`.
+        If a directory is not specified, the file shall be saved in the current directory.
+		
+        The default filename is the input filename suffixed with \"-polyfy\".
+        The default directory is the current directory.
+		
+        If the filename that polyfy attempts to use already exists, a number shall
+        be affixed to the end, starting with \"2\".
 
     $(tput bold)-r, --rotate$(tput sgr0) <first>,<second>
         Specify the rotations done on the first and second polygon. Split the 
@@ -172,13 +186,25 @@ image_w=$(identify -format "%w" $file_f)
 format=$(basename ${file_f##*.})
 dup_c=""
 
-[[ -e $directory/$filename-polyfy.$format ]] && {
-    dup_c=2
-    while [[ -e $directory/$filename-polyfy"$dup_c".$format ]]; do
-        let dup_c++
-    done
-}
-filename="$directory/$filename-polyfy"$dup_c".$format"
+if [[ -z $saveas ]]; then
+    [[ -e $directory/$filename-polyfy.$format ]] && {
+        dup_c=2
+        while [[ -e $directory/$filename-polyfy"$dup_c".$format ]]; do
+            let dup_c++
+        done
+    }
+    filename="$directory/$filename-polyfy"$dup_c".$format"
+else
+    directory=$(dirname $saveas)
+    filename=$(basename ${saveas%.%})
+    [[ -e $directory/$filename.$format ]] && {
+        dup_c=2
+        while [[ -e $directory/$filename"$dup_c".$format ]]; do
+            let dup_c++
+        done
+    }
+    filename="$directory/$filename"$dup_c".$format"
+fi
 
 triangle() {
     length=$(echo "$image_h / $size" | bc -l | awk '{print int($1 + 0.5)}')


### PR DESCRIPTION
So, I added `--output` _and_ it works correctly! A number is still appended to the end if the file already exists, regardless of whether or not `--output` is used.

Additionally, I changed the format of the **SYNPOSIS** section of `polyfy --help` so that it's correct (I think) per `man man`.
